### PR TITLE
Use ubuntu-latest for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   update-tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
         uses: actions/publish-action@v0.3.0


### PR DESCRIPTION
Updating as `ubuntu-20.04` no longer exists.